### PR TITLE
Add confidental? and support_confidentiality? functions

### DIFF
--- a/lib/doorkeeper-sequel/mixins/application_mixin.rb
+++ b/lib/doorkeeper-sequel/mixins/application_mixin.rb
@@ -47,7 +47,25 @@ module DoorkeeperSequel
       def by_uid(uid)
         first(uid: uid.to_s)
       end
+
+      def supports_confidentiality?
+        columns.include?('confidential')
+      end
     end
+
+    # Fallback to existing, default behaviour of assuming all apps to be
+    # confidential if the migration hasn't been run
+    def confidential
+      return super if self.class.supports_confidentiality?
+
+      ActiveSupport::Deprecation.warn 'You are susceptible to security bug ' \
+        'CVE-2018-1000211. Please follow instructions outlined in ' \
+        'Doorkeeper::CVE_2018_1000211_WARNING'
+
+      true
+    end
+
+    alias_method :confidential?, :confidential
 
     private
 


### PR DESCRIPTION
Doorkeeper 4.3 and greater include a security fix which requires a new field in the application named confidential. This PR adds that field to the Application class.

Inspired by the similar PR in [doorkeeper-mongodb](https://github.com/doorkeeper-gem/doorkeeper-mongodb/pull/32)