### PR TITLE
Fix #14: uninitialized Confidential App Generator

### DIFF
--- a/lib/doorkeeper-sequel.rb
+++ b/lib/doorkeeper-sequel.rb
@@ -11,6 +11,7 @@ require 'doorkeeper-sequel/generators/concerns/migration_actions'
 require 'doorkeeper-sequel/generators/application_owner_generator'
 require 'doorkeeper-sequel/generators/migration_generator'
 require 'doorkeeper-sequel/generators/previous_refresh_token_generator'
+require 'doorkeeper-sequel/generators/confidential_applications_generator'
 
 require 'doorkeeper-sequel/mixins/concerns/sequel_compat'
 require 'doorkeeper-sequel/mixins/access_token_mixin'

--- a/lib/doorkeeper-sequel/mixins/application_mixin.rb
+++ b/lib/doorkeeper-sequel/mixins/application_mixin.rb
@@ -41,6 +41,8 @@ module DoorkeeperSequel
         end
       end
 
+      alias_method :confidential?, :confidential
+
       protected
 
       def validate_scopes_match_configured
@@ -70,28 +72,10 @@ module DoorkeeperSequel
         first(uid: uid.to_s)
       end
 
-      def supports_confidentiality?
-        column_names.include?('confidential')
-      end
-
       def column_names
         columns.map(&:to_s)
       end
     end
-
-    # Fallback to existing, default behaviour of assuming all apps to be
-    # confidential if the migration hasn't been run
-    def confidential
-      return super if self.class.supports_confidentiality?
-
-      ActiveSupport::Deprecation.warn 'You are susceptible to security bug ' \
-        'CVE-2018-1000211. Please follow instructions outlined in ' \
-        'Doorkeeper::CVE_2018_1000211_WARNING'
-
-      true
-    end
-
-    alias_method :confidential?, :confidential
 
     private
 


### PR DESCRIPTION
Fixes `uninitialized constant DoorkeeperSequel::ConfidentialApplicationsGenerator`