### PR TITLE
Doorkeeper 5.4 compatibility with `CVE-2020-10187` fix.

### DIFF
--- a/lib/doorkeeper-sequel/mixins/access_token_mixin.rb
+++ b/lib/doorkeeper-sequel/mixins/access_token_mixin.rb
@@ -200,7 +200,7 @@ module DoorkeeperSequel
         end
       end
     end
-
+	
     # It indicates whether the tokens have the same credential
     def same_credential?(access_token)
       application_id == access_token.application_id &&

--- a/lib/doorkeeper/orm/sequel/application.rb
+++ b/lib/doorkeeper/orm/sequel/application.rb
@@ -26,11 +26,14 @@ module Doorkeeper
       end
     end
 
-    def to_json(options = nil)
-      hash = to_hash.dup
-      hash.delete(:secret)
-      hash.merge(secret: plaintext_secret)
-        .to_json(options)
+    def to_json(options = {})
+      json = super(options)
+      hash = JSON.parse(json, symbolize_names: false)
+      if hash.key?("secret")
+        hash["secret"] = plaintext_secret
+        json = hash.to_json
+      end
+      json
     end
 
     def self.authorized_for(resource_owner)


### PR DESCRIPTION
As we have no `as_json` in Sequel, we will first transform to JSON then parse it.

Not a convenient way but it will work until we write our own serializer.

This fixes #33
